### PR TITLE
Use memcpy() to copy the whole block at once

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -436,11 +436,7 @@ static void InvCipher(void)
 
 static void BlockCopy(uint8_t* output, uint8_t* input)
 {
-  uint8_t i;
-  for (i=0;i<KEYLEN;++i)
-  {
-    output[i] = input[i];
-  }
+  memcpy(output, input, KEYLEN);
 }
 
 


### PR DESCRIPTION
We could make that a macro instead:

``` c
#define BlockCopy(output,input) memcpy(output,input,KEYLEN)
```
