### PR TITLE
Fix mutation of input in CBC

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -518,8 +518,8 @@ void AES128_CBC_encrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length,
 
   for(i = 0; i < length; i += KEYLEN)
   {
-    XorWithIv(input);
     BlockCopy(output, input);
+    XorWithIv(output);
     state = (state_t*)output;
     Cipher();
     Iv = output;


### PR DESCRIPTION
"Previously the input buffer passed into the CBC encrypt method was encrypted at the same time as the output buffer. This fix ensures that only the output buffer is encrypted, and the input buffer is not changed." https://github.com/kokke/tiny-AES128-C/pull/13
